### PR TITLE
feat: update dev setup to match current proxy impl

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -242,7 +242,7 @@ Proxies provide the user-facing interface to OptimumP2P.
 ### Subscribe to Topic
 
 ```sh
-curl -X POST http://localhost:8081/api/subscribe \
+curl -X POST http://localhost:8081/api/v1/subscribe \
   -H "Content-Type: application/json" \
   -d '{
     "client_id": "your-client-id", 
@@ -259,7 +259,7 @@ Here, `client_id` is your WebSocket connection identifier. Usually, we use Auth0
 ### WebSocket Connection
 
 ```sh
-wscat -c "ws://localhost:8081/api/ws?client_id=your-client-id"
+wscat -c "ws://localhost:8081/api/v1/ws?client_id=your-client-id"
 ```
 
 This is how clients receive messages published to their subscribed topics.
@@ -269,7 +269,7 @@ This is how clients receive messages published to their subscribed topics.
 ### Publish Message
 
 ```sh
-curl -X POST http://localhost:8081/api/publish \
+curl -X POST http://localhost:8081/api/v1/publish \
   -H "Content-Type: application/json" \
   -d '{
     "client_id": "your-client-id",
@@ -322,7 +322,7 @@ A new Go-based gRPC client implementation is available in `grpc_proxy_client/pro
 * **Bidirectional gRPC Streaming**: Establishes persistent connection with the proxy
 * **REST API Integration**: Uses REST for subscription and publishing
 * **Automatic Client ID Generation**: Generates unique client identifiers
-* **Configurable Keepalive**: Optimized gRPC keepalive settings
+* **Optimized gRPC Connection**: Efficient bidirectional streaming
 * **Message Publishing Loop**: Automated message publishing with configurable delays
 * **Signal Handling**: Graceful shutdown on interrupt
 
@@ -339,8 +339,8 @@ go build -o proxy_client proxy_client.go
 # Subscribe and publish messages
 ./proxy_client -topic=test -threshold=0.7 -count=10 -delay=2s
 
-# Custom keepalive settings
-./proxy_client -topic=test -keepalive-interval=5m -keepalive-timeout=30s
+# Custom connection settings
+./proxy_client -topic=test -threshold=0.7 -count=10
 ```
 
 ### Command Line Flags
@@ -350,8 +350,8 @@ go build -o proxy_client proxy_client.go
 * `-subscribeOnly`: Only subscribe and receive messages
 * `-count`: Number of messages to publish (default: 5)
 * `-delay`: Delay between message publishing (default: 2s)
-* `-keepalive-interval`: gRPC keepalive interval (default: 2m)
-* `-keepalive-timeout`: gRPC keepalive timeout (default: 20s)
+* `-proxy`: Proxy server address (default: "localhost:33211")
+* `-rest`: REST API base URL (default: "http://localhost:8081")
 
 ### Protocol Flow
 

--- a/script/proxy_client.sh
+++ b/script/proxy_client.sh
@@ -8,16 +8,12 @@ cd "$PROXY_CLIENT_DIR"
 go build -o proxy-client ./proxy_client.go
 
 if [ -z "${1:-}" ]; then
-  echo "Usage: $0 (subscribe <topic> <threshold> [keepalive-options])|(publish <topic> <threshold> <message-count> [keepalive-options])" >&2
-  echo "" >&2
-  echo "Keepalive options:" >&2
-  echo "  -keepalive-interval=<duration>  gRPC keepalive ping interval (default: 2m0s)" >&2
-  echo "  -keepalive-timeout=<duration>   gRPC keepalive ping timeout (default: 20s)" >&2
+  echo "Usage: $0 (subscribe <topic> <threshold>)|(publish <topic> <threshold> <message-count>)" >&2
   echo "" >&2
   echo "Examples:" >&2
   echo "  $0 subscribe demo 0.6" >&2
-  echo "  $0 subscribe demo 0.7 -keepalive-interval=5m" >&2
-  echo "  $0 publish demo 0.5 10 -keepalive-timeout=10s" >&2
+  echo "  $0 subscribe demo 0.7" >&2
+  echo "  $0 publish demo 0.5 10" >&2
   exit 1
 fi
 
@@ -27,7 +23,7 @@ shift
 case "$MODE" in
   subscribe)
     if [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
-      echo "Usage: $0 subscribe <topic> <threshold> [keepalive-options]" >&2
+      echo "Usage: $0 subscribe <topic> <threshold>" >&2
       exit 1
     fi
     TOPIC="$1"
@@ -37,7 +33,7 @@ case "$MODE" in
     ;;
   publish)
     if [ -z "${1:-}" ] || [ -z "${2:-}" ] || [ -z "${3:-}" ]; then
-      echo "Usage: $0 publish <topic> <threshold> <message-count> [keepalive-options]" >&2
+      echo "Usage: $0 publish <topic> <threshold> <message-count>" >&2
       exit 1
     fi
     TOPIC="$1"
@@ -48,7 +44,7 @@ case "$MODE" in
     ;;
   *)
     echo "Invalid mode: $MODE" >&2
-    echo "Usage: $0 (subscribe <topic> <threshold> [keepalive-options])|(publish <topic> <threshold> <message-count> [keepalive-options])" >&2
+    echo "Usage: $0 (subscribe <topic> <threshold>)|(publish <topic> <threshold> <message-count>)" >&2
     exit 1
     ;;
 esac

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -61,7 +61,7 @@ api_subscribe() {
   local client_id="$1"
   local topic="$2"
   local threshold="$3"
-  curl -s -X POST "$PROXY_URL/api/subscribe" \
+  curl -s -X POST "$PROXY_URL/api/v1/subscribe" \
     -H "Content-Type: application/json" \
     -d "{\"client_id\": \"$client_id\", \"topic\": \"$topic\", \"threshold\": $threshold}"
 }
@@ -70,7 +70,7 @@ api_publish() {
   local client_id="$1"
   local topic="$2"
   local message="$3"
-  curl -s -X POST "$PROXY_URL/api/publish" \
+  curl -s -X POST "$PROXY_URL/api/v1/publish" \
     -H "Content-Type: application/json" \
     -d "{\"client_id\": \"$client_id\", \"topic\": \"$topic\", \"message\": \"$message\"}"
 }
@@ -134,7 +134,7 @@ echo
 
 # Test 8: Invalid JSON
 echo -e "${YELLOW}Test: Subscribe (invalid JSON)${NC}"
-resp=$(curl -s -X POST "$PROXY_URL/api/subscribe" -H "Content-Type: application/json" -d 'invalid json')
+resp=$(curl -s -X POST "$PROXY_URL/api/v1/subscribe" -H "Content-Type: application/json" -d 'invalid json')
 test_result "$resp" 'invalid JSON' "Subscribe (invalid JSON)"
 echo
 
@@ -171,7 +171,7 @@ if command -v wscat >/dev/null 2>&1; then
   fi
   
   if [[ -n "$TIMEOUT_CMD" ]]; then
-    output=$($TIMEOUT_CMD 5 wscat -c "ws://$PROXY_URL/api/ws?client_id=$CLIENT_ID" 2>&1)
+    output=$($TIMEOUT_CMD 5 wscat -c "ws://$PROXY_URL/api/v1/ws?client_id=$CLIENT_ID" 2>&1)
     if echo "$output" | grep -q "Connected" || echo "$output" | grep -q ">" || echo "$output" | grep -q "connected"; then
       echo -e "${GREEN}[PASS]${NC} WebSocket connection"
       PASS=$((PASS+1))
@@ -203,14 +203,14 @@ test_result "$resp" 'message is missing' "Publish validation (empty message)"
 echo
 
 echo -e "${YELLOW}Test: Publish validation (missing topic)${NC}"
-resp=$(curl -s -X POST "$PROXY_URL/api/publish" \
+resp=$(curl -s -X POST "$PROXY_URL/api/v1/publish" \
   -H "Content-Type: application/json" \
   -d "{\"client_id\": \"$CLIENT_ID\", \"message\": \"Hello\"}")
 test_result "$resp" 'topic is missing' "Publish validation (missing topic)"
 echo
 
 echo -e "${YELLOW}Test: Publish validation (missing message)${NC}"
-resp=$(curl -s -X POST "$PROXY_URL/api/publish" \
+resp=$(curl -s -X POST "$PROXY_URL/api/v1/publish" \
   -H "Content-Type: application/json" \
   -d "{\"client_id\": \"$CLIENT_ID\", \"topic\": \"$TOPIC\"}")
 test_result "$resp" 'message is missing' "Publish validation (missing message)"


### PR DESCRIPTION
- remove keepalive references from client code and documentation
- update API endpoints from /api/ to /api/v1/ format
- update gRPC client with configurable proxy and REST addresses
- update test suite to use v1 API endpoints
- align dev setup with current implementation