### PR TITLE
fix: resolve test suite failures and improve Makefile structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,12 +127,10 @@ jobs:
             echo "P2P node health check failed - continuing with test suite"
           fi
       
-      # TODO: Fix test suite - currently reports 7 failures but marks as successful
-      # Issue: https://github.com/getoptimum/optimum-dev-setup-guide/issues/33
-      # - name: Run Test Suite
-      #   run: |
-      #     chmod +x ./test_suite.sh
-      #     ./test_suite.sh
+         - name: Run Test Suite
+           run: |
+             chmod +x ./test_suite.sh
+             ./test_suite.sh
       
       - name: Cleanup
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -2,25 +2,44 @@ P2P_CLIENT_DIR := ./grpc_p2p_client
 PROXY_CLIENT_DIR := ./grpc_proxy_client
 IDENTITY_DIR := ./identity
 
+# Build targets
+P2P_CLIENT := $(P2P_CLIENT_DIR)/p2p-client
+PROXY_CLIENT := $(PROXY_CLIENT_DIR)/proxy-client
+KEYGEN_BINARY := keygen/generate-p2p-key
+
+# Scripts
+SCRIPTS := ./script/generate-identity.sh ./script/proxy_client.sh ./test_suite.sh
+
+# Helper targets (not shown in help)
+.PHONY: $(P2P_CLIENT) $(PROXY_CLIENT) $(KEYGEN_BINARY) setup-scripts
+
+$(P2P_CLIENT):
+	@cd $(P2P_CLIENT_DIR) && go build -o p2p-client ./p2p_client.go
+
+$(PROXY_CLIENT):
+	@cd $(PROXY_CLIENT_DIR) && go build -o proxy-client ./proxy_client.go
+
+$(KEYGEN_BINARY):
+	@cd keygen && go build -o generate-p2p-key ./generate_p2p_key.go
+
+setup-scripts:
+	@chmod +x $(SCRIPTS)
+
 help: ## Show help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Direct binary usage (recommended):"
 	@echo "  # Subscribe to a topic"
-	@echo "  $(P2P_CLIENT_DIR)/p2p-client -mode=subscribe -topic=\"testtopic\" --addr=\"127.0.0.1:33221\""
+	@echo "  $(P2P_CLIENT) -mode=subscribe -topic=\"testtopic\" --addr=\"127.0.0.1:33221\""
 	@echo ""
 	@echo "  # Publish messages"
-	@echo "  $(P2P_CLIENT_DIR)/p2p-client -mode=publish -topic=\"testtopic\" --addr=\"127.0.0.1:33221\""
-	@echo "  $(P2P_CLIENT_DIR)/p2p-client -mode=publish -topic=\"testtopic\" -msg=\"Hello World\" --addr=\"127.0.0.1:33221\""
+	@echo "  $(P2P_CLIENT) -mode=publish -topic=\"testtopic\" --addr=\"127.0.0.1:33221\""
+	@echo "  $(P2P_CLIENT) -mode=publish -topic=\"testtopic\" -msg=\"Hello World\" --addr=\"127.0.0.1:33221\""
 	@echo ""
 	@echo "  # Publish multiple messages with options"
-	@echo "  $(P2P_CLIENT_DIR)/p2p-client -mode=publish -topic=\"testtopic\" --addr=\"127.0.0.1:33221\" -count=10 -sleep=1s"
+	@echo "  $(P2P_CLIENT) -mode=publish -topic=\"testtopic\" --addr=\"127.0.0.1:33221\" -count=10 -sleep=1s"
 
-build: ## Build all client binaries
-	@echo "Building P2P client..."
-	@cd $(P2P_CLIENT_DIR) && go build -o p2p-client ./p2p_client.go
-	@echo "Building Proxy client..."
-	@cd $(PROXY_CLIENT_DIR) && go build -o proxy-client ./proxy_client.go
+build: $(P2P_CLIENT) $(PROXY_CLIENT) ## Build all client binaries
 	@echo "All clients built successfully"
 
 generate-identity: ## Generate P2P identity (if missing)
@@ -32,16 +51,16 @@ generate-identity: ## Generate P2P identity (if missing)
 		echo "P2P identity already exists at $(IDENTITY_DIR)/p2p.key"; \
 	fi
 
-subscribe: build generate-identity ## subscribe to p2p topic: make subscribe <addr> <topic>
+subscribe: $(P2P_CLIENT) generate-identity ## subscribe to p2p topic: make subscribe <addr> <topic>
 	@set -e; addr="$(word 2,$(MAKECMDGOALS))"; topic="$(word 3,$(MAKECMDGOALS))"; \
 	if [ -z "$$addr" ] || [ -z "$$topic" ]; then \
 		echo "Usage: make subscribe <addr> <topic>" >&2; \
 		echo "Example: make subscribe 127.0.0.1:33221 testtopic" >&2; \
 		exit 1; \
 	fi; \
-	$(P2P_CLIENT_DIR)/p2p-client -mode=subscribe -topic="$$topic" --addr="$$addr"
+	$(P2P_CLIENT) -mode=subscribe -topic="$$topic" --addr="$$addr"
 
-publish: build generate-identity ## publish message to p2p topic: make publish <addr> <topic> <message|random> [count] [sleep]
+publish: $(P2P_CLIENT) generate-identity ## publish message to p2p topic: make publish <addr> <topic> <message|random> [count] [sleep]
 	@set -e; \
 	addr="$(word 2,$(MAKECMDGOALS))"; \
 	topic="$(word 3,$(MAKECMDGOALS))"; \
@@ -66,17 +85,13 @@ publish: build generate-identity ## publish message to p2p topic: make publish <
 	fi; \
 	if [ "$$message" = "random" ]; then \
 		echo "Publishing random messages to topic=$$topic addr=$$addr count=$${count:-1} sleep=$${sleep:-default}"; \
-		$(P2P_CLIENT_DIR)/p2p-client -mode=publish -topic="$$topic" -msg="random" --addr="$$addr" $$extra_args; \
+		$(P2P_CLIENT) -mode=publish -topic="$$topic" -msg="random" --addr="$$addr" $$extra_args; \
 	else \
 		echo "Publishing message '$$message' to topic=$$topic addr=$$addr"; \
-		$(P2P_CLIENT_DIR)/p2p-client -mode=publish -topic="$$topic" -msg="$$message" --addr="$$addr" $$extra_args; \
+		$(P2P_CLIENT) -mode=publish -topic="$$topic" -msg="$$message" --addr="$$addr" $$extra_args; \
 	fi
 
-test: ## Run tests for Go clients
-	@echo "Testing Go clients..."
-	@cd $(P2P_CLIENT_DIR) && go build -o p2p-client ./p2p_client.go
-	@cd $(PROXY_CLIENT_DIR) && go build -o proxy-client ./proxy_client.go
-	@cd keygen && go build -o generate-p2p-key ./generate_p2p_key.go
+test: $(P2P_CLIENT) $(PROXY_CLIENT) $(KEYGEN_BINARY) ## Run tests for Go clients
 	@echo "All Go clients built successfully"
 
 lint: ## Run golangci-lint
@@ -86,21 +101,18 @@ lint: ## Run golangci-lint
 	@cd keygen && golangci-lint run --skip-dirs-use-default || echo "Linting issues found in Keygen"
 	@echo "Linting completed"
 
-test-docker: ## Test Docker Compose setup
+test-docker: setup-scripts ## Test Docker Compose setup
 	@echo "Testing Docker Compose setup..."
-	@chmod +x ./script/generate-identity.sh
 	@./script/generate-identity.sh
 	@docker-compose up --build -d
 	@echo "Waiting for services to be ready..."
 	@sleep 30
 	@docker-compose ps
+	@echo "Running test suite..."
+	@./test_suite.sh
 	@echo "Docker setup test completed"
 
-test-scripts: ## Test shell scripts
-	@echo "Testing shell scripts..."
-	@chmod +x ./script/generate-identity.sh
-	@chmod +x ./script/proxy_client.sh
-	@chmod +x ./test_suite.sh
+test-scripts: setup-scripts ## Test shell scripts
 	@echo "Script tests completed"
 
 validate: ## Validate configuration files
@@ -116,9 +128,7 @@ ci: test lint test-docker test-scripts validate ## Run all CI checks locally
 
 clean: ## Clean build artifacts
 	@echo "Cleaning build artifacts..."
-	@rm -f $(P2P_CLIENT_DIR)/p2p-client
-	@rm -f $(PROXY_CLIENT_DIR)/proxy-client
-	@rm -f keygen/generate-p2p-key
+	@rm -f $(P2P_CLIENT) $(PROXY_CLIENT) $(KEYGEN_BINARY)
 	@echo "Clean complete!"
 
 # Prevent make from interpreting arguments as targets
@@ -126,4 +136,4 @@ clean: ## Clean build artifacts
 	@:
 
 .DEFAULT_GOAL := help
-.PHONY: help build generate-identity subscribe publish test lint test-docker test-scripts validate ci clean
+.PHONY: help build generate-identity subscribe publish test lint test-docker test-scripts validate ci clean setup-scripts


### PR DESCRIPTION
- Fix test_suite.sh to properly handle message deduplication and WebSocket connections
- Add test_result_multi() helper for multiple valid response handling
- Update error message expectations to match actual API responses
- Ensure subscription before publishing to avoid 'topic not assigned' errors
- Add proper exit codes for CI integration (exit 1 on failure)
- Refactor Makefile to eliminate redundant build commands
- Add helper targets for build dependencies and script permissions
