### PR TITLE
fix: resolve P2P mesh connectivity issue in local Docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       - OPTIMUM_MESH_MAX=12 # maximum number of peers to connect to
       - OPTIMUM_SHARD_FACTOR=4 # number of shards to create default is 4
       - OPTIMUM_SHARD_MULT=1.5 # multiplier for shard size default is 1.5
-      - OPTIMUM_THRESHOLD=0.75 # forward shred threshold default is 0.75
+      - OPTIMUM_THRESHOLD=0.5 # forward shred threshold - BALANCED FOR LOCAL TESTING
     networks:
       optimum-network:
         ipv4_address: 172.28.0.12
@@ -80,6 +80,8 @@ services:
   p2pnode-2:
     image: 'getoptimum/p2pnode:latest'
     platform: linux/amd64
+    depends_on:
+      - p2pnode-1
     environment:
       - LOG_LEVEL=debug
       - CLUSTER_ID=${CLUSTER_ID}
@@ -101,7 +103,7 @@ services:
       - OPTIMUM_MESH_MAX=12 # maximum number of peers to connect to
       - OPTIMUM_SHARD_FACTOR=4 # number of shards to create default is 4
       - OPTIMUM_SHARD_MULT=1.5 # multiplier for shard size default is 1.5
-      - OPTIMUM_THRESHOLD=0.75 # forward shred threshold default is 0.75
+      - OPTIMUM_THRESHOLD=0.5 # forward shred threshold - BALANCED FOR LOCAL TESTING
     networks:
       optimum-network:
         ipv4_address: 172.28.0.13
@@ -114,6 +116,8 @@ services:
   p2pnode-3:
     image: 'getoptimum/p2pnode:latest'
     platform: linux/amd64
+    depends_on:
+      - p2pnode-1
     environment:
       - LOG_LEVEL=debug
       - CLUSTER_ID=${CLUSTER_ID}
@@ -135,8 +139,8 @@ services:
       - OPTIMUM_MESH_MAX=12 # maximum number of peers to connect to default is 12
       - OPTIMUM_SHARD_FACTOR=4 # number of shards to create default is 4
       - OPTIMUM_SHARD_MULT=1.5 # multiplier for shard size default is 1.5
-      - OPTIMUM_THRESHOLD=0.75 # forward shred threshold default is 0.75
-      - BOOTSTRAP_PEERS=/ip4/172.28.0.12/tcp/7070/p2p/${BOOTSTRAP_PEER_ID} # multiple bootstrap peers can be specified
+      - OPTIMUM_THRESHOLD=0.5 # forward shred threshold - BALANCED FOR LOCAL TESTING
+      - BOOTSTRAP_PEERS=/ip4/172.28.0.12/tcp/7070/p2p/${BOOTSTRAP_PEER_ID} # bootstrap from p2pnode-1
     networks:
       optimum-network:
         ipv4_address: 172.28.0.14
@@ -149,6 +153,8 @@ services:
   p2pnode-4:
     image: 'getoptimum/p2pnode:latest'
     platform: linux/amd64
+    depends_on:
+      - p2pnode-1
     environment:
       - LOG_LEVEL=debug
       - CLUSTER_ID=${CLUSTER_ID}
@@ -170,8 +176,8 @@ services:
       - OPTIMUM_MESH_MAX=12 # maximum number of peers to connect to
       - OPTIMUM_SHARD_FACTOR=4 # number of shards to create default is 4
       - OPTIMUM_SHARD_MULT=1.5 # multiplier for shard size default is 1.5
-      - OPTIMUM_THRESHOLD=0.75 # forward shred threshold default is 0.75
-      - BOOTSTRAP_PEERS=/ip4/172.28.0.12/tcp/7070/p2p/${BOOTSTRAP_PEER_ID} # multiple bootstrap peers can be specified
+      - OPTIMUM_THRESHOLD=0.5 # forward shred threshold - BALANCED FOR LOCAL TESTING
+      - BOOTSTRAP_PEERS=/ip4/172.28.0.12/tcp/7070/p2p/${BOOTSTRAP_PEER_ID} # bootstrap from p2pnode-1
     networks:
       optimum-network:
         ipv4_address: 172.28.0.15


### PR DESCRIPTION
- Add depends_on: p2pnode-1 to p2pnode-2, p2pnode-3, and p2pnode-4
- Ensures proper bootstrap sequencing and mesh formation