### PR TITLE
fix: drain bidi stream response side in publisher to prevent deadlock

### DIFF
--- a/grpc_p2p_client/cmd/multi-publish/main.go
+++ b/grpc_p2p_client/cmd/multi-publish/main.go
@@ -130,6 +130,19 @@ func sendMessages(ctx context.Context, ip string, datasize int, write bool, data
 		return fmt.Errorf("[%s] ListenCommands failed: %w", ip, err)
 	}
 
+	// Drain the response side of the bidi stream so the per-stream HTTP/2
+	// flow-control window does not fill up and block stream.Send. Without
+	// this drain the publisher deadlocks after ~7-8 publications at
+	// payload sizes >=100KB, because each publish triggers several
+	// trace-event Response messages from the server.
+	go func() {
+		for {
+			if _, err := stream.Recv(); err != nil {
+				return
+			}
+		}
+	}()
+
 	println(fmt.Sprintf("Connected to node at: %s…", ip))
 
 	for i := 0; i < *count; i++ {

--- a/grpc_p2p_client/cmd/single/main.go
+++ b/grpc_p2p_client/cmd/single/main.go
@@ -115,6 +115,18 @@ func publish(ctx context.Context, stream protobuf.CommandStream_ListenCommandsCl
 		log.Fatal("-msg is required in publish mode")
 	}
 
+	// Drain the response side of the bidi stream so the per-stream HTTP/2
+	// flow-control window does not fill up and block stream.Send. Without
+	// this drain a multi-message publish (-count >> 1 with large -msg)
+	// deadlocks after ~7-8 publications at payload sizes >=100KB.
+	go func() {
+		for {
+			if _, err := stream.Recv(); err != nil {
+				return
+			}
+		}
+	}()
+
 	for i := 0; i < count; i++ {
 		start := time.Now()
 		var data []byte


### PR DESCRIPTION
Closes #74

## Summary

The publisher CLIs (`cmd/multi-publish` and `cmd/single` in publish mode) open the `ListenCommands` bidi stream and only call `stream.Send()` in a loop. They never `stream.Recv()`. The server emits trace-event `Response` messages on every publish; without a drain on the client side, the per-stream HTTP/2 flow-control window fills, the server handler blocks, and `stream.Send` on the client eventually blocks too. Result: publisher hangs after ~7-8 publications at payloads >=100 KB. Full root-cause analysis in the linked issue.

This PR adds a drain goroutine in each of the two affected call sites. Trace events are discarded (they were not used by the publisher anyway).

## Changes

```
grpc_p2p_client/cmd/multi-publish/main.go | 13 +++++++++++++
grpc_p2p_client/cmd/single/main.go        | 12 ++++++++++++
2 files changed, 25 insertions(+)
```

Both call sites add the same pattern immediately after `client.ListenCommands(ctx)` succeeds:

```go
// Drain the response side of the bidi stream so the per-stream HTTP/2
// flow-control window does not fill up and block stream.Send.
go func() {
    for {
        if _, err := stream.Recv(); err != nil {
            return
        }
    }
}()
```

The goroutine exits when the connection closes (the `defer conn.Close()` already in `sendMessages` at the end of the function triggers the exit). No leak.

## Why this approach

- Minimal change: 5 lines per call site, no proto modification, no API change, no behaviour change at the user level (the publisher was already discarding trace events implicitly by not reading them).
- Matches the pattern already used by `cmd/multi-subscribe` and `cmd/single` in subscribe mode, which do `stream.Recv` in their main loop.
- An alternative would be to switch `Publish` to a unary RPC, but that requires a proto change and breaks compatibility with the current `Request`/`Response` typing used by both subscribe and publish on the same `ListenCommands` stream.

## Verification

Run on the local Docker stack from this repo, image `getoptimum/p2pnode:v0.0.1-rc16`. Before applying the patch the OLD multi-publish hangs:

```bash
./grpc_p2p_client/p2p-multi-publish -topic=t -ipfile=ips.txt \
  -start-index=0 -end-index=1 -count=40 -datasize=102400 -sleep=200ms
# 7 publications, then hangs indefinitely.
```

After this patch, with rebuilt binaries:

| test | result |
|---|---|
| `-count=40 -datasize=102400 -sleep=200ms` (100 KB × 40) | completes in ~8.06 s |
| `-count=20 -datasize=1048576 -sleep=400ms` (1 MB × 20) | completes in ~8.10 s |
| `-count=10 -datasize=2516582 -sleep=600ms` (2.4 MB × 10) | completes in ~6.12 s |
| `-count=50 -datasize=1024 -sleep=100ms` (1 KB × 50, the size that worked before) | unchanged, completes normally |

Sample output from the 100 KB run (post-fix):

```
[127.0.0.1:33221] published 102416 bytes to "fix-test-100kb" (took 282us)
[127.0.0.1:33221] published 102416 bytes to "fix-test-100kb" (took 367us)
[... 38 more ...]

real    0m8.058s
```

## Notes for reviewers

- The drain goroutine intentionally has no logging on `stream.Recv` errors. The errors here are the natural shutdown signal (stream closed because connection closed) and logging them would be noise.
- `cmd/multi-subscribe` and `cmd/single` in subscribe mode are not touched — they already drain in their main loop.
- I considered using a small buffered channel to forward the responses for later inspection (e.g. to add a `-trace` flag to multi-publish symmetrical to multi-subscribe). That seemed out of scope for a bug fix. Happy to do it as a follow-up if useful.

## Test environment

- Repo: this branch off `main` at `bd8c0b8`.
- Stack: `docker-compose-optimum.yml` 4 p2pnodes + 2 proxies, defaults.
- OS: Ubuntu 22.04 LTS x86_64.
- Go: 1.26.3 (snap).
- Docker: 29.3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential deadlocks occurring when publishing multiple messages with large payloads. Enhanced stream receive handling prevents flow-control window saturation that could block subsequent publish requests, improving reliability across publish operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getoptimum/optimum-dev-setup-guide/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->